### PR TITLE
SWAPI changed their API URL

### DIFF
--- a/script2.js
+++ b/script2.js
@@ -2,7 +2,7 @@
 const fetch = require('node-fetch');
 
 const getPeoplePromise = (fetch) => {
-  return fetch('https://swapi.co/api/people')
+  return fetch('https://swapi.dev/api/people')
     .then(response => response.json())
     .then(data => {
       return {
@@ -12,7 +12,7 @@ const getPeoplePromise = (fetch) => {
     })
 }
 const getPeople = async (fetch) => {
-  const getRequest = await fetch('https://swapi.co/api/people');
+  const getRequest = await fetch('https://swapi.dev/api/people');
   const data =  await getRequest.json();
   // console.log(data);
   return {

--- a/script2.test.js
+++ b/script2.test.js
@@ -32,7 +32,7 @@ it('getPeople returns count and results', () => {
   expect.assertions(4)
   return swapi.getPeoplePromise(mockFetch).then(data => {
     expect(mockFetch.mock.calls.length).toBe(1);
-    expect(mockFetch).toBeCalledWith('https://swapi.co/api/people');
+    expect(mockFetch).toBeCalledWith('https://swapi.dev/api/people');
     expect(data.count).toEqual(87);
     expect(data.results.length).toBeGreaterThan(5);
   })


### PR DESCRIPTION
Was taking a testing refresher and noticed that SWAPi moved from swapi.co to swapi.dev
Made the change in script2.js and script2.test.js